### PR TITLE
Add support for singlehtml builder

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@ Optionally, you can configure the filename of the inventory object:
 How to use
 ----------
 
-Once installed, run the new `inventory-html` or `inventory-singlhtml` builder::
+Once installed, run the new `inventory-html` or `inventory-singlehtml` builder::
 
     sphinx-build -b inventory ./source ./build
 

--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@ Optionally, you can configure the filename of the inventory object:
 How to use
 ----------
 
-Once installed, run the new `inventory-html` or `inventory-singlehtml` builder::
+Once installed, run the new ``inventory-html`` or ``inventory-singlehtml`` builder::
 
     sphinx-build -b inventory ./source ./build
 

--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@ Optionally, you can configure the filename of the inventory object:
 How to use
 ----------
 
-Once installed, run the new `inventory` builder::
+Once installed, run the new `inventory-html` or `inventory-singlhtml` builder::
 
     sphinx-build -b inventory ./source ./build
 

--- a/sphinx_inventory_builder/__init__.py
+++ b/sphinx_inventory_builder/__init__.py
@@ -16,7 +16,7 @@ from sphinx.builders.singlehtml import SingleFileHTMLBuilder
 from sphinx.util.inventory import InventoryFile
 from sphinx.util.logging import getLogger
 
-__version__ = '0.2.0'
+__version__ = "0.2.0"
 
 logger = getLogger(__name__)
 
@@ -25,6 +25,7 @@ class _InventoryMixin:
     """
     Shared behavior: don’t write HTML, just dump objects.inv.
     """
+
     format = "inventory"
     epilog = "The inventory file is in %(outdir)s."
 
@@ -50,11 +51,13 @@ class _InventoryMixin:
 
 class InventoryHtmlBuilder(_InventoryMixin, StandaloneHTMLBuilder):
     """Inventory builder with html-style URIs."""
+
     name = "inventory-html"
 
 
 class InventorySingleHtmlBuilder(_InventoryMixin, SingleFileHTMLBuilder):
     """Inventory builder with singlehtml-style URIs."""
+
     name = "inventory-singlehtml"
 
 
@@ -62,9 +65,9 @@ def disable_intersphinx(app, config):
     inventory_builders = ["inventory-html", "inventory-singlehtml"]
     if detect_builder(app) in inventory_builders:
         config.intersphinx_mapping = {}
-        config.intersphinx_disabled_reftypes = ['*']
+        config.intersphinx_disabled_reftypes = ["*"]
 
-        config.suppress_warnings = ['ref.*', 'docutils']
+        config.suppress_warnings = ["ref.*", "docutils"]
 
 
 def detect_builder(app):
@@ -86,7 +89,7 @@ def ignore_external_refs(app, env, node, contnode):
     Returns None to ignore it (no warning), or returns contnode to continue.
     """
     # intersphinx adds a custom attribute to its nodes:
-    if getattr(node, 'intersphinx', False):
+    if getattr(node, "intersphinx", False):
         # This is an external reference — ignore it completely
         return None
 
@@ -102,8 +105,8 @@ def setup(app: Sphinx) -> dict[str, Any]:
     app.add_builder(InventorySingleHtmlBuilder)
 
     def on_builder_inited(app):
-        inventory_builders = ('inventory-html', 'inventory-singlehtml')
-        singlehtml_builders = ('inventory-html', 'inventory-singlehtml')
+        inventory_builders = ("inventory-html", "inventory-singlehtml")
+        singlehtml_builders = ("inventory-html", "inventory-singlehtml")
 
         if app.builder.name in inventory_builders:
             app.connect("missing-reference", ignore_external_refs)
@@ -115,9 +118,9 @@ def setup(app: Sphinx) -> dict[str, Any]:
             # Rewrites "#document-{page}#{anchor}" → "{root_doc}.html#{anchor}"
             def patched_get_target_uri(docname, typ=None):
                 uri = original_get_target_uri(docname, typ)
-                if uri.startswith('#document-'):
-                    next_hash = uri.find('#', len('#document-'))
-                    suffix = uri[next_hash:] if next_hash != -1 else ''
+                if uri.startswith("#document-"):
+                    next_hash = uri.find("#", len("#document-"))
+                    suffix = uri[next_hash:] if next_hash != -1 else ""
                     return app.config.root_doc + app.builder.out_suffix + suffix
                 return uri
 

--- a/sphinx_inventory_builder/__init__.py
+++ b/sphinx_inventory_builder/__init__.py
@@ -5,41 +5,141 @@ Inventory builder
 A customized builder which only generates intersphinx "object.inv"
 inventory files. The documentation files are not written.
 """
-from __future__ import annotations
 
+import sys
 from os import path
 from typing import Any
 
 from sphinx.application import Sphinx
-from sphinx.builders.dummy import DummyBuilder
+from sphinx.builders.html import StandaloneHTMLBuilder
+from sphinx.builders.singlehtml import SingleFileHTMLBuilder
 from sphinx.util.inventory import InventoryFile
+from sphinx.util.logging import getLogger
 
-__version__ = "0.1.0"
+__version__ = '0.2.0'
+
+logger = getLogger(__name__)
 
 
-class InventoryBuilder(DummyBuilder):
+class _InventoryMixin:
     """
-    A customized builder which only generates intersphinx "object.inv"
-    inventory files. The documentation files are not written.
+    Shared behavior: don’t write HTML, just dump objects.inv.
     """
-
-    name = "inventory"
     format = "inventory"
-    epilog = "The inventory files are in %(outdir)s."
+    epilog = "The inventory file is in %(outdir)s."
+
+    def get_outdated_docs(self) -> set[str]:
+        return self.env.found_docs
+
+    def write_doc(self, docname, doctree):
+        # suppress writing HTML files
+        return
+
+    def copy_static_files(self):
+        return
 
     def finish(self) -> None:
         """
         Only write the inventory files.
         """
         assert self.env is not None
-
         InventoryFile.dump(
             path.join(self.outdir, self.app.config.inventory_filename), self.env, self
         )
 
 
+class InventoryHtmlBuilder(_InventoryMixin, StandaloneHTMLBuilder):
+    """Inventory builder with html-style URIs."""
+    name = "inventory-html"
+
+
+class InventorySingleHtmlBuilder(_InventoryMixin, SingleFileHTMLBuilder):
+    """Inventory builder with singlehtml-style URIs."""
+    name = "inventory-singlehtml"
+
+
+def disable_intersphinx(app, config):
+    inventory_builders = ["inventory-html", "inventory-singlehtml"]
+    if detect_builder(app) in inventory_builders:
+        config.intersphinx_mapping = {}
+        config.intersphinx_disabled_reftypes = ['*']
+
+        config.suppress_warnings = ['ref.*', 'docutils']
+
+
+def detect_builder(app):
+    argv = sys.argv
+    try:
+        i = list(argv).index("-b")
+        name = argv[i + 1]
+    except ValueError:
+        for a in argv:
+            if a.startswith("--builder="):
+                name = a.split("=", 1)[1]
+                break
+    return name
+
+
+def ignore_external_refs(app, env, node, contnode):
+    """
+    Called when Sphinx can’t resolve a reference.
+    Returns None to ignore it (no warning), or returns contnode to continue.
+    """
+    # intersphinx adds a custom attribute to its nodes:
+    if getattr(node, 'intersphinx', False):
+        # This is an external reference — ignore it completely
+        return None
+
+    # All other refs (internal) will trigger normal warnings
+    return contnode
+
+
+def filter_duplicate_equation_warnings(app):
+    """
+    Filter out duplicate equation warnings.
+    A monkey patch until this fix is available: https://github.com/sphinx-doc/sphinx/pull/13929
+    """
+    inventory_builders = ["inventory-html"]
+    if app.builder.name not in inventory_builders:
+        return
+
+    import logging
+
+    class DuplicateEquationFilter(logging.Filter):
+        def filter(self, record):
+            return 'duplicate label of equation' not in record.getMessage()
+
+    # Get the Sphinx logger (not your extension's logger)
+    sphinx_logger = logging.getLogger('sphinx')
+    sphinx_logger.addFilter(DuplicateEquationFilter())
+
+
 def setup(app: Sphinx) -> dict[str, Any]:
     app.add_config_value("inventory_filename", default="objects.inv", rebuild="")
 
-    app.add_builder(InventoryBuilder)
+    # Register both builders
+    app.add_builder(InventoryHtmlBuilder)
+    app.add_builder(InventorySingleHtmlBuilder)
+
+    def on_builder_inited(app):
+        if app.builder.name in ('inventory-singlehtml', 'singlehtml'):
+            original_get_target_uri = app.builder.get_target_uri
+
+            # Patch get_target_uri to fix internal links for single-page builds.
+            # Rewrites "#document-{page}#{anchor}" → "{root_doc}.html#{anchor}"
+            def patched_get_target_uri(docname, typ=None):
+                uri = original_get_target_uri(docname, typ)
+                if uri.startswith('#document-'):
+                    next_hash = uri.find('#', len('#document-'))
+                    suffix = uri[next_hash:] if next_hash != -1 else ''
+                    return app.config.root_doc + app.builder.out_suffix + suffix
+                return uri
+
+            app.builder.get_target_uri = patched_get_target_uri
+
+    app.connect("config-inited", disable_intersphinx)
+    app.connect("builder-inited", on_builder_inited)
+    app.connect("builder-inited", filter_duplicate_equation_warnings)
+    app.connect("missing-reference", ignore_external_refs)
+
     return {"parallel_read_safe": True}

--- a/sphinx_inventory_builder/__init__.py
+++ b/sphinx_inventory_builder/__init__.py
@@ -94,26 +94,6 @@ def ignore_external_refs(app, env, node, contnode):
     return contnode
 
 
-def filter_duplicate_equation_warnings(app):
-    """
-    Filter out duplicate equation warnings.
-    A monkey patch until this fix is available: https://github.com/sphinx-doc/sphinx/pull/13929
-    """
-    inventory_builders = ["inventory-html"]
-    if app.builder.name not in inventory_builders:
-        return
-
-    import logging
-
-    class DuplicateEquationFilter(logging.Filter):
-        def filter(self, record):
-            return 'duplicate label of equation' not in record.getMessage()
-
-    # Get the Sphinx logger (not your extension's logger)
-    sphinx_logger = logging.getLogger('sphinx')
-    sphinx_logger.addFilter(DuplicateEquationFilter())
-
-
 def setup(app: Sphinx) -> dict[str, Any]:
     app.add_config_value("inventory_filename", default="objects.inv", rebuild="")
 
@@ -139,7 +119,6 @@ def setup(app: Sphinx) -> dict[str, Any]:
 
     app.connect("config-inited", disable_intersphinx)
     app.connect("builder-inited", on_builder_inited)
-    app.connect("builder-inited", filter_duplicate_equation_warnings)
     app.connect("missing-reference", ignore_external_refs)
 
     return {"parallel_read_safe": True}

--- a/sphinx_inventory_builder/__init__.py
+++ b/sphinx_inventory_builder/__init__.py
@@ -102,7 +102,13 @@ def setup(app: Sphinx) -> dict[str, Any]:
     app.add_builder(InventorySingleHtmlBuilder)
 
     def on_builder_inited(app):
-        if app.builder.name in ('inventory-singlehtml', 'singlehtml'):
+        inventory_builders = ('inventory-html', 'inventory-singlehtml')
+        singlehtml_builders = ('inventory-html', 'inventory-singlehtml')
+
+        if app.builder.name in inventory_builders:
+            app.connect("missing-reference", ignore_external_refs)
+
+        if app.builder.name in singlehtml_builders:
             original_get_target_uri = app.builder.get_target_uri
 
             # Patch get_target_uri to fix internal links for single-page builds.
@@ -119,6 +125,5 @@ def setup(app: Sphinx) -> dict[str, Any]:
 
     app.connect("config-inited", disable_intersphinx)
     app.connect("builder-inited", on_builder_inited)
-    app.connect("missing-reference", ignore_external_refs)
 
     return {"parallel_read_safe": True}


### PR DESCRIPTION
## Summary of changes

- Add support for `singlehtml` HTML builder with `inventory-singlehtml`
- Automatically disable intersphinx and supress reference warnings since they don't effect the `objects.inv`
- Patch `singlehtml` references so that they work with intersphinx

### Breaking Changes

- Change `inventory` builder to `inventory-html` for consistent naming